### PR TITLE
fixes #113: add migrations/ to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -106,3 +106,4 @@ bower_components
 static/bower_components
 # PyCharm
 .idea/
+migrations/


### PR DESCRIPTION
	- closes crowdresearch/crowdsource-platform#113