### PR TITLE
fix data source in autocomplete of template designer to be empty in new element properties

### DIFF
--- a/static/templates/template/properties.html
+++ b/static/templates/template/properties.html
@@ -25,8 +25,8 @@
     <!--label>Item Source (csv column i.e. label_1)</label-->
     <md-autocomplete
         md-selected-item="template.selectedItem.data_source"
-        md-search-text="csvSearchText"
-        md-items="csvHeader in project.querySearch(csvSearchText)"
+        md-search-text="template.selectedItem.csvSearchText"
+        md-items="csvHeader in project.querySearch(template.selectedItem.csvSearchText)"
         md-item-text="csvHeader"
         md-min-length="0"
         placeholder="Type a Header from your uploaded CSV">


### PR DESCRIPTION
An effect of this fix is that a new member csvSearchText is added to the item object