### PR TITLE
remove data persisting in create project workflow even after project design has been submitted

### DIFF
--- a/static/js/project/controllers/project.controller.js
+++ b/static/js/project/controllers/project.controller.js
@@ -31,7 +31,7 @@
       self.upload = upload;
       self.initMicroFlag = initMicroFlag;
 
-      self.currentProject = Project.retrieve();
+      self.currentProject = {};
       self.currentProject.payment = self.currentProject.payment || {};
 
       self.querySearch = function(query) {


### PR DESCRIPTION
#453 

initialize  self.currentProject as an empty object every time the project controller is loaded. 
