### PR TITLE
rating optimizations

### DIFF
--- a/crowdsourcing/permissions/rating.py
+++ b/crowdsourcing/permissions/rating.py
@@ -1,0 +1,8 @@
+from rest_framework import permissions
+
+
+class IsRatingOwner(permissions.BasePermission):
+    def has_object_permission(self, request, view, obj):
+        if view.action in ('update', 'destroy',):
+            return obj.origin == request.user.userprofile
+        return True

--- a/crowdsourcing/permissions/rating.py
+++ b/crowdsourcing/permissions/rating.py
@@ -3,6 +3,4 @@ from rest_framework import permissions
 
 class IsRatingOwner(permissions.BasePermission):
     def has_object_permission(self, request, view, obj):
-        if view.action in ('update', 'destroy',):
-            return obj.origin == request.user.userprofile
-        return True
+        return obj.origin == request.user.userprofile

--- a/crowdsourcing/viewsets/rating.py
+++ b/crowdsourcing/viewsets/rating.py
@@ -96,11 +96,11 @@ class RatingViewset(viewsets.ModelViewSet):
         for task_worker in task_workers:
           module = task_worker.task.module
           modules.append(module)
-          pending_reviews[(module.id, module.project.owner.profile.user.id)] = {
+          pending_reviews[(module.id, module.project.owner.profile_id)] = {
             #"task_worker": TaskWorkerSerializer(instance=task_worker).data,
-            "project_owner_alias": module.project.owner.profile.user.username,
+            "project_owner_alias": module.project.owner.alias,
             "project_name": module.project.name,
-            "target": module.project.owner.profile.id,
+            "target": module.project.owner.profile_id,
             "module": module.id,
             "module_name": module.name
           }

--- a/crowdsourcing/viewsets/rating.py
+++ b/crowdsourcing/viewsets/rating.py
@@ -97,7 +97,7 @@ class RatingViewset(viewsets.ModelViewSet):
           module = task_worker.task.module
           modules.append(module)
           pending_reviews[(module.id, module.project.owner.profile.user.id)] = {
-            "task_worker": TaskWorkerSerializer(instance=task_worker).data,
+            #"task_worker": TaskWorkerSerializer(instance=task_worker).data,
             "project_owner_alias": module.project.owner.profile.user.username,
             "project_name": module.project.name,
             "target": module.project.owner.profile.user.id,

--- a/crowdsourcing/viewsets/rating.py
+++ b/crowdsourcing/viewsets/rating.py
@@ -100,7 +100,7 @@ class RatingViewset(viewsets.ModelViewSet):
             #"task_worker": TaskWorkerSerializer(instance=task_worker).data,
             "project_owner_alias": module.project.owner.profile.user.username,
             "project_name": module.project.name,
-            "target": module.project.owner.profile.user.id,
+            "target": module.project.owner.profile.id,
             "module": module.id,
             "module_name": module.name
           }

--- a/crowdsourcing/viewsets/rating.py
+++ b/crowdsourcing/viewsets/rating.py
@@ -8,11 +8,12 @@ from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
 from crowdsourcing.models import WorkerRequesterRating, Module, Task, TaskWorker, Worker, Project
 from crowdsourcing.serializers.rating import WorkerRequesterRatingSerializer
-
+from crowdsourcing.permissions.rating import IsRatingOwner
 
 class WorkerRequesterRatingViewset(viewsets.ModelViewSet):
     queryset = WorkerRequesterRating.objects.all()
     serializer_class = WorkerRequesterRatingSerializer
+    permission_classes = [IsAuthenticated, IsRatingOwner]
 
     def create(self, request, *args, **kwargs):
         wrr_serializer = WorkerRequesterRatingSerializer(data=request.data)


### PR DESCRIPTION
restricts object permissions only to the owner of the rating entry
task_worker removed from serialization as it's not needed
more optimizations needed for rating viewset