### PR TITLE
Pandas fix for installation on Ubuntu 15.x

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -15,7 +15,7 @@ gunicorn==19.3.0
 hashids
 httpie
 numpy==1.9.2
-pandas==0.16.2
+pandas==0.17.1
 paypalrestsdk
 psycopg2==2.6
 sendgrid


### PR DESCRIPTION
Updated `requirements.txt` and changed pandas version to `pandas 0.17.1` to resolve [Issue #629](https://github.com/crowdresearch/crowdsource-platform/issues/629)