### PR TITLE
#641: Display notification message on successful registration.

### DIFF
--- a/static/js/authentication/controllers/register.controller.js
+++ b/static/js/authentication/controllers/register.controller.js
@@ -7,8 +7,8 @@
 
     angular
         .module('crowdsource.authentication.controllers')
-        .controller('RegisterController', ['$location', '$scope', 'Authentication', 'cfpLoadingBar',
-            function RegisterController($location, $scope, Authentication, cfpLoadingBar) {
+        .controller('RegisterController', ['$location', '$scope', 'Authentication', 'cfpLoadingBar','$mdToast',
+            function RegisterController($location, $scope, Authentication, cfpLoadingBar, $mdToast) {
 
                 activate();
                 /**
@@ -39,6 +39,7 @@
                         vm.password1, vm.password2).then(function () {
 
                             $location.url('/login');
+                            $mdToast.showSimple('Email with an activation link has been sent.');
                         }, function (data, status) {
 
                             //Global errors


### PR DESCRIPTION
After successful registration, user should be presented with a notification message mentioning that an email with activation link has been sent.

This PR let user see the message "Email with an activation link has been sent", when the user is redirected from registration page to login page.

![register-alert](https://cloud.githubusercontent.com/assets/4050813/12459711/1cc1066c-bfd6-11e5-9269-a3562223190d.png)