### PR TITLE
Enable CORS for External Work Submission

### DIFF
--- a/crowdsourcing/viewsets/task.py
+++ b/crowdsourcing/viewsets/task.py
@@ -244,8 +244,6 @@ class TaskWorkerResultViewSet(viewsets.ModelViewSet):
 
 
 class ExternalSubmit(APIView):
-    parser_classes = (JSONParser,)
-
     def post(self, request, *args, **kwargs):
         identifier = request.query_params.get('daemo_id', False)
         if not identifier:

--- a/crowdsourcing/viewsets/task.py
+++ b/crowdsourcing/viewsets/task.py
@@ -1,4 +1,3 @@
-from rest_framework.parsers import JSONParser
 from rest_framework.views import APIView
 from rest_framework import status, viewsets
 from rest_framework.response import Response
@@ -6,6 +5,7 @@ from rest_framework.decorators import detail_route, list_route
 from django.shortcuts import get_object_or_404
 from django.utils import timezone
 from django.db.models import Q
+
 from rest_framework.permissions import IsAuthenticated
 
 from crowdsourcing.serializers.task import *
@@ -143,7 +143,7 @@ class TaskWorkerViewSet(viewsets.ModelViewSet):
     @list_route(methods=['get'], url_path='list-my-tasks')
     def list_my_tasks(self, request, *args, **kwargs):
         project_id = request.query_params.get('project_id', -1)
-        task_workers = TaskWorker.objects.exclude(task_status=TaskWorker.STATUS_SKIPPED).\
+        task_workers = TaskWorker.objects.exclude(task_status=TaskWorker.STATUS_SKIPPED). \
             filter(worker=request.user.userprofile.worker, task__project_id=project_id)
         serializer = TaskWorkerSerializer(instance=task_workers, many=True,
                                           fields=(

--- a/crowdsourcing/viewsets/task.py
+++ b/crowdsourcing/viewsets/task.py
@@ -1,3 +1,4 @@
+from rest_framework.parsers import JSONParser
 from rest_framework.views import APIView
 from rest_framework import status, viewsets
 from rest_framework.response import Response
@@ -243,6 +244,8 @@ class TaskWorkerResultViewSet(viewsets.ModelViewSet):
 
 
 class ExternalSubmit(APIView):
+    parser_classes = (JSONParser,)
+
     def post(self, request, *args, **kwargs):
         identifier = request.query_params.get('daemo_id', False)
         if not identifier:

--- a/csp/settings.py
+++ b/csp/settings.py
@@ -203,6 +203,10 @@ USERNAME_MAX_LENGTH = 30
 
 # CORS
 CORS_ORIGIN_ALLOW_ALL = True
+# Use only to restrict to specific servers/domains
+# CORS_ORIGIN_WHITELIST = (
+#     '127.0.0.1:8005',
+# )
 CORS_URLS_REGEX = r'^/api/done/*$'
 CORS_ALLOW_METHODS = (
     'GET',

--- a/csp/settings.py
+++ b/csp/settings.py
@@ -73,6 +73,7 @@ INSTALLED_APPS = (
     'django.contrib.staticfiles',
     'django.contrib.sessions',
     'django.contrib.postgres',
+    'corsheaders',
     'compressor',
     'crispy_forms',
     'rest_framework',
@@ -85,6 +86,7 @@ INSTALLED_APPS = (
 MIDDLEWARE_CLASSES = (
     'django.contrib.sessions.middleware.SessionMiddleware',
     'django.contrib.auth.middleware.AuthenticationMiddleware',
+    'corsheaders.middleware.CorsMiddleware',
     'django.middleware.common.CommonMiddleware',
     'django.middleware.csrf.CsrfViewMiddleware',
     'crowdsourcing.middleware.active.CustomActiveViewMiddleware',
@@ -198,6 +200,15 @@ PASSWORD_RESET_ALLOWED = True
 
 LOGIN_URL = '/login'
 USERNAME_MAX_LENGTH = 30
+
+# CORS
+CORS_ORIGIN_ALLOW_ALL = True
+CORS_URLS_REGEX = r'^/api/done/*$'
+CORS_ALLOW_METHODS = (
+    'GET',
+    'POST',
+    'OPTIONS'
+)
 
 SITE_HOST = os.environ.get('SITE_HOST', 'https://daemo.herokuapp.com')
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,6 +6,7 @@ Django==1.9
 django-appconf==1.0.1
 django-autofixture==0.10.1
 django-compressor==2.0
+django-cors-headers==1.1.0
 django-crispy-forms==1.5.2
 dj-database-url==0.3.0
 django-oauth-toolkit==0.9.0


### PR DESCRIPTION
- Allow any server to post work via /api/done/
- Only allow JSON requests for external work. JSON is used to ensure request is pre-flighted one always and thus follow security measures for AJAX requests and CORS

Reference: https://developer.mozilla.org/en-US/docs/Web/HTTP/Access_control_CORS