### PR TITLE
New task creation flow (not fully done)

### DIFF
--- a/static/templates/project/authoring.html
+++ b/static/templates/project/authoring.html
@@ -38,298 +38,318 @@
         </div>
     </div>
     <div class="_main-content-body" ng-class="{'_sm': $mdMedia('sm'), '_gt-sm': $mdMedia('gt-sm')}">
-        <div class="_project-title layout-row">
-            <md-input-container class="_authoring_content">
-                <label>Title</label>
-                <input ng-disabled="project.isDisabled()" ng-model="project.project.name" autocomplete="off">
-            </md-input-container>
-            <div class="layout-row layout-align-start-start">
-                <div class="_hash-id">Project Key <span class="_id">{{ project.project.hash_id }}</span></div>
-            </div>
+      <md-tabs class="dark" md-stretch-tabs="always" md-center-tabs="true" md-swipe-content="true" md-dynamic-height="true">
+          <md-tab label="Select a task type">
+            <md-content class="md-padding">
+              <div layout="row" layout-align="center">
+                <p class="light-text" style="text-align: center">What task are you trying to do here?</p>
+              </div>
+            </md-content>
+          </md-tab>
+          <md-tab label="Design your task">
+            <md-content class="md-padding">
+              <div class="_project-title layout-row">
+                  <md-input-container class="_authoring_content">
+                      <label>Title</label>
+                      <input ng-disabled="project.isDisabled()" ng-model="project.project.name" autocomplete="off">
+                  </md-input-container>
+                  <div class="layout-row layout-align-start-start">
+                      <div class="_hash-id">Project Key <span class="_id">{{ project.project.hash_id }}</span></div>
+                  </div>
 
-        </div>
-        <div class="_error _authoring_content"
-             ng-if="project.project.status==project.status.STATUS_IN_PROGRESS || project.project.status==project.status.STATUS_PAUSED">
-            This project has launched. {{ project.unlockText }} click
-            <div ng-disabled="project.createRevisionInProgress" ng-click="project.createRevision();"
-                 class="_button-special">{{ project.unlockButtonText }}
-            </div>
-        </div>
-        <div class="_authoring_content" ng-if="!project.showInstructions">
-            <div style="padding-left: 4px">If you want to include variables in your task, use bracket syntax. For
-                example,
-                <span class="_variable">{{ '\{\{variablename\}\}' }}</span>.
-            </div>
-        </div>
-        <div ng-controller="TemplateController as template" ng-if="!project.showInstructions">
-            <div class="_template-builder">
-                <ng-include src="'/static/templates/template/base.html'"></ng-include>
-            </div>
-            <div ng-if="!project.isDisabled()" class="_item-toolbar">
-                <md-button ng-repeat="component in template.templateComponents"
-                           ng-click="template.addComponent(component)">
-                    <md-icon md-font-set="material-icons">{{ component.icon }}</md-icon>
-                    <md-tooltip>
-                        {{ component.tooltip }}
-                    </md-tooltip>
-                </md-button>
-            </div>
-        </div>
-        <div class="_meta-info" layout="column" ng-if="!project.showInstructions">
-            <form name="metaForm">
-                <div class="_authoring_content" layout="row">
-                    <md-input-container>
-                        <label>Workers per task</label>
-                        <input ng-disabled="project.isDisabled()" name="repetition" required type="number" min="1"
-                               ng-model="project.project.repetition">
-                        <!--div ng-show="metaForm.repetition.$touched && metaForm.repetition.$invalid"
-                             ng-messages="metaForm.repetition.$error" role="alert" multiple>
-                          <div ng-message="required" class="my-message">You must supply the number of workers per task.</div>
-                        </div-->
-                    </md-input-container>
-                    <md-input-container class="_ml-24 md-block md-input-has-placeholder">
-                        <label>Price</label>
-                        <div><span class="currency-symbol">$</span><input ng-disabled="project.isDisabled()" name="price" required type="number" min="0.01" decimals="2" integers="15" is-currency
-                               step="0.01" ng-model="project.project.price" class="currency-field"></div>
-                        <!--div ng-show="metaForm.price.$touched && metaForm.price.$invalid"
-                             ng-messages="metaForm.price.$error" role="alert" multiple>
-                          <div ng-message="required" class="my-message">You must supply the task price.</div>
-                        </div-->
-                    </md-input-container>
-                    <div class="_meta-files _ml-24 layout-column layout-align-center-center">
-                      {{ (project.project.repetition * project.project.price || 0) | currency}} per task
-                        <!--a class="_link" href="/api/project/{{ project.project.id }}/sample-script/"
-                           target="_blank">Download initial script</a-->
-                    </div>
+              </div>
+              <div class="_error _authoring_content"
+                   ng-if="project.project.status==project.status.STATUS_IN_PROGRESS || project.project.status==project.status.STATUS_PAUSED">
+                  This project has launched. {{ project.unlockText }} click
+                  <div ng-disabled="project.createRevisionInProgress" ng-click="project.createRevision();"
+                       class="_button-special">{{ project.unlockButtonText }}
+                  </div>
+              </div>
+              <div class="_authoring_content" ng-if="!project.showInstructions">
+                  <div style="padding-left: 4px">If you want to include variables in your task, use bracket syntax. For
+                      example,
+                      <span class="_variable">{{ '\{\{variablename\}\}' }}</span>.
+                  </div>
+              </div>
+              <div ng-controller="TemplateController as template" ng-if="!project.showInstructions">
+                  <div class="_template-builder">
+                      <ng-include src="'/static/templates/template/base.html'"></ng-include>
+                  </div>
+                  <div ng-if="!project.isDisabled()" class="_item-toolbar">
+                      <md-button ng-repeat="component in template.templateComponents"
+                                 ng-click="template.addComponent(component)">
+                          <md-icon md-font-set="material-icons">{{ component.icon }}</md-icon>
+                          <md-tooltip>
+                              {{ component.tooltip }}
+                          </md-tooltip>
+                      </md-button>
+                  </div>
+              </div>
+            </md-content>
+          </md-tab>
+          <md-tab label="Fill in task details">
+            <md-content class="md-padding">
+              <div layout="row" layout-align="center">
+                  <p style="text-align:center;font-size:1.5em"><b>We at DAEMO believe in fair task compensation</b></br>use our optional fair-price estimator</p>
+              </div>
+              <div class="_meta-info" layout="column" ng-if="!project.showInstructions">
+                  <form name="metaForm">
+                      <div class="_authoring_content" layout="row">
+                          <md-input-container>
+                              <label>Workers per task</label>
+                              <input ng-disabled="project.isDisabled()" name="repetition" required type="number" min="1"
+                                     ng-model="project.project.repetition">
+                              <!--div ng-show="metaForm.repetition.$touched && metaForm.repetition.$invalid"
+                                   ng-messages="metaForm.repetition.$error" role="alert" multiple>
+                                <div ng-message="required" class="my-message">You must supply the number of workers per task.</div>
+                              </div-->
+                          </md-input-container>
+                          <md-input-container class="_ml-24 md-block md-input-has-placeholder">
+                              <label>Price</label>
+                              <div><span class="currency-symbol">$</span><input ng-disabled="project.isDisabled()" name="price" required type="number" min="0.01" decimals="2" integers="15" is-currency
+                                     step="0.01" ng-model="project.project.price" class="currency-field"></div>
+                              <!--div ng-show="metaForm.price.$touched && metaForm.price.$invalid"
+                                   ng-messages="metaForm.price.$error" role="alert" multiple>
+                                <div ng-message="required" class="my-message">You must supply the task price.</div>
+                              </div-->
+                          </md-input-container>
+                          <div class="_meta-files _ml-24 layout-column layout-align-center-center">
+                            {{ (project.project.repetition * project.project.price || 0) | currency}} per task
+                              <!--a class="_link" href="/api/project/{{ project.project.id }}/sample-script/"
+                                 target="_blank">Download initial script</a-->
+                          </div>
 
-                    <!--div ng-if="!project.isDisabled()" class="_meta-files _ml-24" layout="column">
-                        <div ng-if="project.project.batch_files.length==0" ng-cloak="" class="_upload-text"><a
-                                class="_file-upload"
-                                ngf-select
-                                ngf-change="project.upload($files)">Upload</a>
-                            a spreadsheet to create a copy of this task for each row
-                        </div>
-                    </div>
-                    <md-list ng-if="!project.isDisabled() && project.project.batch_files.length>0" class="_meta-sources"
-                             ng-cloak="">
-                        <md-list-item class="md-line-2" ng-repeat="file in project.project.batch_files">
-                            <div class="md-list-item-text">
-                                <div><a class="_file-upload">{{ file.name }}</a> ({{ file.size }})</div>
-                            </div>
-                            <md-icon ng-click="project.removeFile(file.id)" class="_file-action"
-                                     md-font-set="material-icons">clear
-                            </md-icon>
-                        </md-list-item>
-                    </md-list-->
-                    <div layout="row" layout-align="end center" flex style="position: relative">
+                          <!--div ng-if="!project.isDisabled()" class="_meta-files _ml-24" layout="column">
+                              <div ng-if="project.project.batch_files.length==0" ng-cloak="" class="_upload-text"><a
+                                      class="_file-upload"
+                                      ngf-select
+                                      ngf-change="project.upload($files)">Upload</a>
+                                  a spreadsheet to create a copy of this task for each row
+                              </div>
+                          </div>
+                          <md-list ng-if="!project.isDisabled() && project.project.batch_files.length>0" class="_meta-sources"
+                                   ng-cloak="">
+                              <md-list-item class="md-line-2" ng-repeat="file in project.project.batch_files">
+                                  <div class="md-list-item-text">
+                                      <div><a class="_file-upload">{{ file.name }}</a> ({{ file.size }})</div>
+                                  </div>
+                                  <md-icon ng-click="project.removeFile(file.id)" class="_file-action"
+                                           md-font-set="material-icons">clear
+                                  </md-icon>
+                              </md-list-item>
+                          </md-list-->
+                          <div layout="row" layout-align="end center" flex style="position: relative">
 
-                        <md-button ng-click="project.isExpanded = !project.isExpanded" class="button-icon">Advanced
-                            <span class="icon">
-                                <i class="material-icons" ng-show="!project.isExpanded">chevron_right</i>
-                                <i class="material-icons" ng-show="project.isExpanded">keyboard_arrow_down</i>
-                            </span>
-                        </md-button>
-                    </div>
-                </div>
-
-                <div class="_authoring_content" ng-show="project.isExpanded">
-                    <div layout="row">
-                        <!--div class="md-datepicker-input _mr-24" layout="column">
-                            <label>Deadline</label>
-                            <md-datepicker ng-disabled="project.isDisabled()" class="md-input-has-value larger"
-                                           name="deadline"
-                                           ng-model="project.project.deadline" md-min-date="project.minDate"
-                                           md-placeholder="mm/dd/yyyy">
-                            </md-datepicker>
-                        </div-->
-                        <md-input-container class="md-block larger">
-                            <label>Minutes allotted per task</label>
-                            <input ng-disabled="project.isDisabled()" name="timeout" type="number"
-                                   ng-model="project.project.timeout" min="1">
-                        </md-input-container>
-                    </div>
-                    <div>
-                      <div layout="row">
-                        <md-input-container>
-                          <md-checkbox ng-disabled="project.isDisabled()" name="has_review"
-                                       ng-model="project.project.has_review">Peer Review
-                          </md-checkbox>
-                        </md-input-container>
-                        <md-input-container class="_ml-24" ng-if="project.project.has_review">
-                          <label>$/Task</label>
-                          <input ng-disabled="project.isDisabled()" name="review_price" required type="number" min="0.01"
-                                 step="0.01"
-                                 ng-model="project.project.review_price">
-                        </md-input-container>
+                              <md-button ng-click="project.isExpanded = !project.isExpanded" class="button-icon">Advanced
+                                  <span class="icon">
+                                      <i class="material-icons" ng-show="!project.isExpanded">chevron_right</i>
+                                      <i class="material-icons" ng-show="project.isExpanded">keyboard_arrow_down</i>
+                                  </span>
+                              </md-button>
+                          </div>
                       </div>
-                    </div>
-                    <div>
-                        <span class="_sub-header">Mechanical Turk Qualifications</span>
-                        <div>
-                            <div class="layout-row" ng-repeat="item in project.project.qualification_items"
-                                 ng-if="item.expression.attribute!='worker_groups'">
-                                <md-input-container flex="33">
-                                    <label>Attribute</label>
-                                    <md-select ng-model="item.expression.attribute"
-                                               aria-label="qualification attribute" ng-disabled="true">
-                                        <md-option value="{{ option.value }}"
-                                                   ng-repeat="option in project.qualificationItemOptions">
-                                            {{ option.name }}
-                                        </md-option>
-                                    </md-select>
-                                </md-input-container>
-                                <md-input-container flex="20">
-                                    <label>Operator</label>
-                                    <md-select ng-disabled="project.isDisabled()"
-                                               ng-change="project.updateQualificationItem(item)"
-                                               class="_ml-16" ng-model="item.expression.operator"
-                                               aria-label="qualification operator">
-                                        <md-option value="{{ option.value }}"
-                                                   ng-repeat="option in project.qualificationOperatorMapping[item.expression.attribute]">
-                                            {{ option.name }}
-                                        </md-option>
-                                    </md-select>
-                                </md-input-container>
-                                <md-input-container class="_ml-16">
-                                    <label>Value(s)</label>
-                                    <input ng-disabled="project.isDisabled()"
-                                           ng-change="project.updateQualificationItem(item)"
-                                           ng-if="item.expression.attribute=='approval_rate'" type="number"
-                                           ng-model="item.expression.value" min="1" max="99">
-                                    <input ng-disabled="project.isDisabled()"
-                                           ng-change="project.updateQualificationItem(item)"
-                                           ng-if="item.expression.attribute=='total_tasks'" type="number"
-                                           ng-model="item.expression.value" min="1">
-                                    <input ng-disabled="project.isDisabled()"
-                                           ng-change="project.updateQualificationItem(item)"
-                                           ng-if="item.expression.attribute=='location'" type="text"
-                                           ng-model="item.expression.value">
-                                </md-input-container>
-                                <md-icon ng-if="!project.isDisabled()"
-                                         ng-click="project.deleteQualificationItem(item.id)" class="_icon-18 _clickable"
-                                         md-font-set="material-icons">delete
-                                </md-icon>
-                                <span flex="20"></span>
+
+                      <div class="_authoring_content" ng-show="project.isExpanded">
+                          <div layout="row">
+                              <!--div class="md-datepicker-input _mr-24" layout="column">
+                                  <label>Deadline</label>
+                                  <md-datepicker ng-disabled="project.isDisabled()" class="md-input-has-value larger"
+                                                 name="deadline"
+                                                 ng-model="project.project.deadline" md-min-date="project.minDate"
+                                                 md-placeholder="mm/dd/yyyy">
+                                  </md-datepicker>
+                              </div-->
+                              <md-input-container class="md-block larger">
+                                  <label>Minutes allotted per task</label>
+                                  <input ng-disabled="project.isDisabled()" name="timeout" type="number"
+                                         ng-model="project.project.timeout" min="1">
+                              </md-input-container>
+                          </div>
+                          <div>
+                            <div layout="row">
+                              <md-input-container>
+                                <md-checkbox ng-disabled="project.isDisabled()" name="has_review"
+                                             ng-model="project.project.has_review">Peer Review
+                                </md-checkbox>
+                              </md-input-container>
+                              <md-input-container class="_ml-24" ng-if="project.project.has_review">
+                                <label>$/Task</label>
+                                <input ng-disabled="project.isDisabled()" name="review_price" required type="number" min="0.01"
+                                       step="0.01"
+                                       ng-model="project.project.review_price">
+                              </md-input-container>
                             </div>
-                        </div>
-                        <div class="layout-row"
-                             ng-if="project.showNewItemForm()">
-                            <md-input-container>
-                                <label>Attribute</label>
-                                <md-select ng-disabled="project.isDisabled()"
-                                           ng-model="project.qualificationItemAttribute"
-                                           aria-label="qualification attribute">
-                                    <md-option value="{{ option.value }}"
-                                               ng-repeat="option in project.qualificationItemOptions">
-                                        {{ option.name }}
-                                    </md-option>
-                                </md-select>
-                            </md-input-container>
-                            <md-input-container>
-                                <label>Operator</label>
-                                <md-select ng-disabled="project.isDisabled()" class="_ml-16"
-                                           ng-model="project.qualificationItemOperator"
-                                           aria-label="qualification operator">
-                                    <md-option value="{{ option.value }}"
-                                               ng-repeat="option in project.qualificationOperatorMapping[project.qualificationItemAttribute]">
-                                        {{ option.name }}
-                                    </md-option>
-                                </md-select>
-                            </md-input-container>
-                            <md-input-container class="_ml-16"
-                                                ng-if="project.qualificationItemAttribute=='approval_rate' &&
-                                                project.qualificationItemAttribute &&
-                                                project.qualificationItemAttribute!='worker_groups'">
-                                <label>Value(s)</label>
-                                <input ng-disabled="project.isDisabled()"
-                                       type="number"
-                                       ng-model="project.qualificationItemValue" min="1" max="99">
+                          </div>
+                          <div>
+                              <span class="_sub-header">Mechanical Turk Qualifications</span>
+                              <div>
+                                  <div class="layout-row" ng-repeat="item in project.project.qualification_items"
+                                       ng-if="item.expression.attribute!='worker_groups'">
+                                      <md-input-container flex="33">
+                                          <label>Attribute</label>
+                                          <md-select ng-model="item.expression.attribute"
+                                                     aria-label="qualification attribute" ng-disabled="true">
+                                              <md-option value="{{ option.value }}"
+                                                         ng-repeat="option in project.qualificationItemOptions">
+                                                  {{ option.name }}
+                                              </md-option>
+                                          </md-select>
+                                      </md-input-container>
+                                      <md-input-container flex="20">
+                                          <label>Operator</label>
+                                          <md-select ng-disabled="project.isDisabled()"
+                                                     ng-change="project.updateQualificationItem(item)"
+                                                     class="_ml-16" ng-model="item.expression.operator"
+                                                     aria-label="qualification operator">
+                                              <md-option value="{{ option.value }}"
+                                                         ng-repeat="option in project.qualificationOperatorMapping[item.expression.attribute]">
+                                                  {{ option.name }}
+                                              </md-option>
+                                          </md-select>
+                                      </md-input-container>
+                                      <md-input-container class="_ml-16">
+                                          <label>Value(s)</label>
+                                          <input ng-disabled="project.isDisabled()"
+                                                 ng-change="project.updateQualificationItem(item)"
+                                                 ng-if="item.expression.attribute=='approval_rate'" type="number"
+                                                 ng-model="item.expression.value" min="1" max="99">
+                                          <input ng-disabled="project.isDisabled()"
+                                                 ng-change="project.updateQualificationItem(item)"
+                                                 ng-if="item.expression.attribute=='total_tasks'" type="number"
+                                                 ng-model="item.expression.value" min="1">
+                                          <input ng-disabled="project.isDisabled()"
+                                                 ng-change="project.updateQualificationItem(item)"
+                                                 ng-if="item.expression.attribute=='location'" type="text"
+                                                 ng-model="item.expression.value">
+                                      </md-input-container>
+                                      <md-icon ng-if="!project.isDisabled()"
+                                               ng-click="project.deleteQualificationItem(item.id)" class="_icon-18 _clickable"
+                                               md-font-set="material-icons">delete
+                                      </md-icon>
+                                      <span flex="20"></span>
+                                  </div>
+                              </div>
+                              <div class="layout-row"
+                                   ng-if="project.showNewItemForm()">
+                                  <md-input-container>
+                                      <label>Attribute</label>
+                                      <md-select ng-disabled="project.isDisabled()"
+                                                 ng-model="project.qualificationItemAttribute"
+                                                 aria-label="qualification attribute">
+                                          <md-option value="{{ option.value }}"
+                                                     ng-repeat="option in project.qualificationItemOptions">
+                                              {{ option.name }}
+                                          </md-option>
+                                      </md-select>
+                                  </md-input-container>
+                                  <md-input-container>
+                                      <label>Operator</label>
+                                      <md-select ng-disabled="project.isDisabled()" class="_ml-16"
+                                                 ng-model="project.qualificationItemOperator"
+                                                 aria-label="qualification operator">
+                                          <md-option value="{{ option.value }}"
+                                                     ng-repeat="option in project.qualificationOperatorMapping[project.qualificationItemAttribute]">
+                                              {{ option.name }}
+                                          </md-option>
+                                      </md-select>
+                                  </md-input-container>
+                                  <md-input-container class="_ml-16"
+                                                      ng-if="project.qualificationItemAttribute=='approval_rate' &&
+                                                      project.qualificationItemAttribute &&
+                                                      project.qualificationItemAttribute!='worker_groups'">
+                                      <label>Value(s)</label>
+                                      <input ng-disabled="project.isDisabled()"
+                                             type="number"
+                                             ng-model="project.qualificationItemValue" min="1" max="99">
 
-                            </md-input-container>
-                            <md-input-container class="_ml-16"
-                                                ng-if="project.qualificationItemAttribute=='total_tasks' &&
-                                                project.qualificationItemAttribute &&
-                                                project.qualificationItemAttribute!='worker_groups'">
-                                <label>Value(s)</label>
-                                <input ng-disabled="project.isDisabled()" type="number"
-                                       ng-model="project.qualificationItemValue" min="1">
-                            </md-input-container>
-                            <md-input-container class="_ml-16"
-                                                ng-if="project.qualificationItemAttribute=='location' &&
-                                                project.qualificationItemAttribute &&
-                                                project.qualificationItemAttribute!='worker_groups'">
-                                <label>Value(s)</label>
-                                <input ng-disabled="project.isDisabled()"
-                                       type="text"
-                                       ng-model="project.qualificationItemValue">
+                                  </md-input-container>
+                                  <md-input-container class="_ml-16"
+                                                      ng-if="project.qualificationItemAttribute=='total_tasks' &&
+                                                      project.qualificationItemAttribute &&
+                                                      project.qualificationItemAttribute!='worker_groups'">
+                                      <label>Value(s)</label>
+                                      <input ng-disabled="project.isDisabled()" type="number"
+                                             ng-model="project.qualificationItemValue" min="1">
+                                  </md-input-container>
+                                  <md-input-container class="_ml-16"
+                                                      ng-if="project.qualificationItemAttribute=='location' &&
+                                                      project.qualificationItemAttribute &&
+                                                      project.qualificationItemAttribute!='worker_groups'">
+                                      <label>Value(s)</label>
+                                      <input ng-disabled="project.isDisabled()"
+                                             type="text"
+                                             ng-model="project.qualificationItemValue">
 
-                            </md-input-container>
-                            <md-button
-                                    ng-disabled="project.isDisabled() || (!project.qualificationItemAttribute || !project.qualificationItemOperator
-                                    || project.qualificationItemValue==null) && project.qualificationItemAttribute!='worker_groups'"
-                                    ng-click="project.createQualificationItem()">Add
-                            </md-button>
-                        </div>
-                    </div>
+                                  </md-input-container>
+                                  <md-button
+                                          ng-disabled="project.isDisabled() || (!project.qualificationItemAttribute || !project.qualificationItemOperator
+                                          || project.qualificationItemValue==null) && project.qualificationItemAttribute!='worker_groups'"
+                                          ng-click="project.createQualificationItem()">Add
+                                  </md-button>
+                              </div>
+                          </div>
 
-                    <div class="_mt-16 _mb-16" ng-if="project.workerGroups.length || !project.isDisabled()">
-                        <span class="_sub-header">Worker selection</span>
-                        <div>
-                            <md-input-container ng-show="project.workerGroups.length" class="_mr-16">
-                                <label>Group</label>
-                                <md-select ng-disabled="project.isDisabled()"
-                                           ng-change="project.addWorkerGroupQualification()" class="_ml-16"
-                                           ng-model="project.project.workerGroup"
-                                           aria-label="worker group">
-                                    <md-option value="0">None</md-option>
-                                    <md-option value="{{ option.id }}"
-                                               ng-repeat="option in project.workerGroups">
-                                        {{ option.name }}
-                                    </md-option>
-                                </md-select>
-                            </md-input-container>
+                          <div class="_mt-16 _mb-16" ng-if="project.workerGroups.length || !project.isDisabled()">
+                              <span class="_sub-header">Worker selection</span>
+                              <div>
+                                  <md-input-container ng-show="project.workerGroups.length" class="_mr-16">
+                                      <label>Group</label>
+                                      <md-select ng-disabled="project.isDisabled()"
+                                                 ng-change="project.addWorkerGroupQualification()" class="_ml-16"
+                                                 ng-model="project.project.workerGroup"
+                                                 aria-label="worker group">
+                                          <md-option value="0">None</md-option>
+                                          <md-option value="{{ option.id }}"
+                                                     ng-repeat="option in project.workerGroups">
+                                              {{ option.name }}
+                                          </md-option>
+                                      </md-select>
+                                  </md-input-container>
 
-                            <span ng-if="!project.isDisabled()" class="_link"
-                                  ng-click="project.openWorkerGroupNew($event)">Add group</span>
-                        </div>
+                                  <span ng-if="!project.isDisabled()" class="_link"
+                                        ng-click="project.openWorkerGroupNew($event)">Add group</span>
+                              </div>
 
-                    </div>
-                    <!--div>
-                        <span class="_sub-header">Project dependencies</span>
-                    </div-->
+                          </div>
+                          <!--div>
+                              <span class="_sub-header">Project dependencies</span>
+                          </div-->
 
-                    <!--div>
-                        <div class="_sub-header">Post my task to Mechanical Turk if nobody on Daemo is available</div>
-                        <md-switch ng-disabled="project.isDisabled()" ng-change="project.AWSChanged($event)"
-                                   ng-model="project.project.post_mturk">Post to
-                            Mechanical Turk
-                        </md-switch>
-                        <div class="_small-note _error">{{ project.AWSError }}</div>
-                    </div-->
-                </div>
+                          <!--div>
+                              <div class="_sub-header">Post my task to Mechanical Turk if nobody on Daemo is available</div>
+                              <md-switch ng-disabled="project.isDisabled()" ng-change="project.AWSChanged($event)"
+                                         ng-model="project.project.post_mturk">Post to
+                                  Mechanical Turk
+                              </md-switch>
+                              <div class="_small-note _error">{{ project.AWSError }}</div>
+                          </div-->
+                      </div>
 
 
-                <div class="_authoring_content _advanced" layout="row">
-                    <div ng-hide="project.isExpanded || !project.project.deadline" class="_mr-24">Deadline:
-                        {{ project.project.deadline | date:'MMM d, y' || "Not Defined" }}</div>
-                    <div ng-hide="project.isExpanded|| !project.project.timeout">
-                        Minutes allotted per task: {{ project.project.timeout || 0 }} min.
-                    </div>
-                </div>
-                <!--div ng-if="!project.isExpanded && project.aws_account.id"
-                     class="_small-note _authoring_content _advanced _aws-note">*Your task
-                    will automatically be posted to Mechanical Turk, click "Advanced"
-                    to change that setting or configure AWS Keys.
-                </div-->
-            </form>
-            <div class="layout-row layout-align-end-center" style="padding: 16px">
-                <md-button ng-if="project.showResume()" ng-click="project.done($event)"
-                           class="return">{{ project.resumeButtonText }}</md-button>
-                <!--div ng-if="project.showResume()" ng-click="project.done($event)"
-                     class="_button-special _primary-btn">{{ project.resumeButtonText }}
-                </div-->
-            </div>
-        </div>
+                      <div class="_authoring_content _advanced" layout="row">
+                          <div ng-hide="project.isExpanded || !project.project.deadline" class="_mr-24">Deadline:
+                              {{ project.project.deadline | date:'MMM d, y' || "Not Defined" }}</div>
+                          <div ng-hide="project.isExpanded|| !project.project.timeout">
+                              Minutes allotted per task: {{ project.project.timeout || 0 }} min.
+                          </div>
+                      </div>
+                      <!--div ng-if="!project.isExpanded && project.aws_account.id"
+                           class="_small-note _authoring_content _advanced _aws-note">*Your task
+                          will automatically be posted to Mechanical Turk, click "Advanced"
+                          to change that setting or configure AWS Keys.
+                      </div-->
+                  </form>
+                  <div class="layout-row layout-align-end-center" style="padding: 16px">
+                      <md-button ng-if="project.showResume()" ng-click="project.done($event)"
+                                 class="return">{{ project.resumeButtonText }}</md-button>
+                      <!--div ng-if="project.showResume()" ng-click="project.done($event)"
+                           class="_button-special _primary-btn">{{ project.resumeButtonText }}
+                      </div-->
+                  </div>
+              </div>
+            </md-content>
+          </md-tab>
+        </md-tabs>
         <div ng-if="project.showInstructions && !project.isProfileCompleted">
             <ng-include src="'/static/templates/user/demographics.html'"></ng-include>
         </div>


### PR DESCRIPTION
To do:
- implement horizontal list of 'blocks' or 'cards' that each represent one type of task (eg. image tagging, etc.)
- implement arrow at the bottom of each tab that 'scrolls' to the next tab (ie. next step in task creation)
- make the tabs disappear and display a new view entirely when "Done" is pressed

Notes:
- I set the "md-dynamic-height" attribute to "true" because I had a problem with the size of the views under each tab (they were fixed to a small size), but I don't know if we want to keep it dynamically resizeable like that
- I didn't do the launch part yet (after pressing "Done")