### PR TITLE
Don't show "other responses" button if we know that they're only asking for one

### DIFF
--- a/static/templates/project/submission-review.html
+++ b/static/templates/project/submission-review.html
@@ -125,7 +125,8 @@
 
                                     <md-button
                                             class="_small-button" style="font-size: smaller"
-                                            ng-click="review.getOtherResponses(task)">
+                                            ng-click="review.getOtherResponses(task)"
+                                            ng-if="review.resolvedData.repetition > 1">
                                         <md-icon style="font-size: 18px"
                                                  md-font-set="material-icons">
                                             {{ !task.showResponses ? 'keyboard_arrow_down' : 'keyboard_arrow_up' }}</md-icon>


### PR DESCRIPTION
Check the number of assignments they've asked for, and only show the button if it's >1